### PR TITLE
Struts 6.3.0.2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Struts2 url plugin prerelease
+# Struts2 url plugin prerelease
 
 ([Official project page](https://code.google.com/p/struts2urlplugin/))
 
@@ -22,8 +22,8 @@ This builds on jitpack.io, for example:
 <dependency>
     <groupId>com.github.tizra</groupId>
     <artifactId>struts2urlplugin</artifactId>
-    <version>0.1-tizra.2</version>
+    <version>0.1-tizra.12</version>
 </dependency>
 ```
 
-Note that you have to create a tag 0.1-tizra.2 (or whatever, to name the version of the resulting build.)
+Note that you have to create a tag 0.1-tizra.13 (or whatever, to name the version of the resulting build.)

--- a/apps/default-example/pom.xml
+++ b/apps/default-example/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.blueskyminds.struts2.urlplugin</groupId>
   <artifactId>default-example</artifactId>
   <packaging>war</packaging>
-  <version>0.1-tizra.5</version>
+  <version>0.1-tizra.12</version>
   <name>Example Struts2 WebApp with default URL settings</name>
 
   <parent>
@@ -14,17 +14,17 @@
     <version>1</version>
   </parent>
 
-  <dependencies>    
+  <dependencies>
    <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.31</version>
+      <version>6.3.0.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.blueskyminds.struts2</groupId>
       <artifactId>struts2-url-plugin</artifactId>
-      <version>0.1-tizra.5</version>
+      <version>0.1-tizra.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/apps/default-example/src/main/resources/struts.xml
+++ b/apps/default-example/src/main/resources/struts.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE struts PUBLIC
-        "-//Apache Software Foundation//DTD Struts Configuration 2.0//EN"
-        "http://struts.apache.org/dtds/struts-2.0.dtd">
+        "-//Apache Software Foundation//DTD Struts Configuration 6.0//EN"
+        "http://struts.apache.org/dtds/struts-6.0.dtd">
 <struts>
 
   <constant name="" value=""/>
-  
+
   <package name="example" extends="struts-default" namespace="/">
 
     <action name="example" class="com.blueskyminds.struts2.urlplugin.apps.ExampleAction">

--- a/apps/index-example/pom.xml
+++ b/apps/index-example/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.blueskyminds.struts2.urlplugin</groupId>
   <artifactId>index-example</artifactId>
   <packaging>war</packaging>
-  <version>0.1-tizra.5</version>
+  <version>0.1-tizra.12</version>
   <name>Example Struts2 WebApp with index actions</name>
   <url>http://www.blueskyminds.com.au</url>
 
@@ -19,13 +19,13 @@
    <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.31</version>
+      <version>6.3.0.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.blueskyminds.struts2</groupId>
       <artifactId>struts2-url-plugin</artifactId>
-      <version>0.1-tizra.5</version>
+      <version>0.1-tizra.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/apps/index-example/src/main/resources/struts.xml
+++ b/apps/index-example/src/main/resources/struts.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE struts PUBLIC
-        "-//Apache Software Foundation//DTD Struts Configuration 2.0//EN"
-        "http://struts.apache.org/dtds/struts-2.0.dtd">
+        "-//Apache Software Foundation//DTD Struts Configuration 6.0//EN"
+        "http://struts.apache.org/dtds/struts-6.0.dtd">
 <struts>
 
   <constant name="struts.urlplugin.configFile" value="struts-defaultIndex-urls.xml"/>

--- a/apps/namespace-example/pom.xml
+++ b/apps/namespace-example/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.blueskyminds.struts2.urlplugin</groupId>
   <artifactId>namespace-example</artifactId>
   <packaging>war</packaging>
-  <version>0.1-tizra.5</version>
+  <version>0.1-tizra.12</version>
   <name>Example Struts2 WebApp with variables in the namespace</name>
   <url>http://www.blueskyminds.com.au</url>
 
@@ -19,13 +19,13 @@
    <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.31</version>
+      <version>6.3.0.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.blueskyminds.struts2</groupId>
       <artifactId>struts2-url-plugin</artifactId>
-      <version>0.1-tizra.5</version>
+      <version>0.1-tizra.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/apps/namespace-example/src/main/resources/struts.xml
+++ b/apps/namespace-example/src/main/resources/struts.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE struts PUBLIC
-        "-//Apache Software Foundation//DTD Struts Configuration 2.0//EN"
-        "http://struts.apache.org/dtds/struts-2.0.dtd">
+        "-//Apache Software Foundation//DTD Struts Configuration 6.0//EN"
+        "http://struts.apache.org/dtds/struts-6.0.dtd">
 <struts>
   <constant name="struts.urlplugin.configFile" value="struts-namespace-urls.xml"/>
 

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -28,15 +28,15 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.12.1</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>17</source>
+            <target>17</target>
           </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.1.3</version>
+          <version>3.2.5</version>
           <configuration>
             <includes>
               <include>**/*Test.java</include>
@@ -55,28 +55,33 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jsp-api</artifactId>
-      <version>2.0</version>
+      <groupId>javax.servlet.jsp</groupId>
+      <artifactId>javax.servlet.jsp-api</artifactId>
+      <version>2.3.3</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.0.4</version>
+      <version>1.3.0</version>
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>2.13.0</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.23.0</version>
     </dependency>
   </dependencies>
 

--- a/apps/rest-example/pom.xml
+++ b/apps/rest-example/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.blueskyminds.struts2.urlplugin</groupId>
   <artifactId>rest-example</artifactId>
   <packaging>war</packaging>
-  <version>0.1-tizra.5</version>
+  <version>0.1-tizra.11</version>
   <name>Example Struts2 WebApp using RESTful URLs and the REST plugin</name>
   <url>http://www.blueskyminds.com.au</url>
 
@@ -19,17 +19,22 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.31</version>
+      <version>6.3.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-rest-plugin</artifactId>
-      <version>2.5.16,)</version>
+      <version>6.3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.struts</groupId>
+      <artifactId>struts2-convention-plugin</artifactId>
+      <version>6.3.0.2</version>
     </dependency>
     <dependency>
       <groupId>com.blueskyminds.struts2</groupId>
       <artifactId>struts2-url-plugin</artifactId>
-      <version>0.1-tizra.5</version>
+      <version>0.1-tizra.12</version>
     </dependency>
   </dependencies>
 

--- a/apps/rest-example/src/main/java/com/blueskyminds/struts2/urlplugin/apps/OrdersController.java
+++ b/apps/rest-example/src/main/java/com/blueskyminds/struts2/urlplugin/apps/OrdersController.java
@@ -2,9 +2,9 @@ package com.blueskyminds.struts2.urlplugin.apps;
 
 import java.util.Collection;
 
-import org.apache.struts2.config.Result;
-import org.apache.struts2.config.Results;
-import org.apache.struts2.dispatcher.ServletActionRedirectResult;
+import org.apache.struts2.convention.annotation.Result;
+import org.apache.struts2.convention.annotation.Results;
+import org.apache.struts2.result.ServletActionRedirectResult;
 import org.apache.struts2.rest.DefaultHttpHeaders;
 import org.apache.struts2.rest.HttpHeaders;
 
@@ -13,10 +13,10 @@ import com.opensymphony.xwork2.Validateable;
 import com.opensymphony.xwork2.ValidationAwareSupport;
 
 @Results({
-    @Result(name="success", type=ServletActionRedirectResult.class, value="orders") 
+    @Result(name="success", type="redirectAction", location="orders")
 })
 public class OrdersController extends ValidationAwareSupport implements ModelDriven<Object>, Validateable{
-    
+
     private Order model = new Order();
     private String id;
     private Collection<Order> list;
@@ -33,7 +33,7 @@ public class OrdersController extends ValidationAwareSupport implements ModelDri
         return new DefaultHttpHeaders("index")
             .disableCaching();
     }
-    
+
     // GET /orders/1/edit
     public String edit() {
         return "edit";
@@ -84,7 +84,7 @@ public class OrdersController extends ValidationAwareSupport implements ModelDri
         }
         this.id = id;
     }
-    
+
     public Object getModel() {
         return (list != null ? list : model);
     }

--- a/apps/rest-example/src/main/resources/struts.xml
+++ b/apps/rest-example/src/main/resources/struts.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE struts PUBLIC
-        "-//Apache Software Foundation//DTD Struts Configuration 2.0//EN"
-        "http://struts.apache.org/dtds/struts-2.0.dtd">
+        "-//Apache Software Foundation//DTD Struts Configuration 6.0//EN"
+        "http://struts.apache.org/dtds/struts-6.0.dtd">
 <struts>
   <constant name="struts.urlplugin.configFile" value="struts-rest-urls.xml"/>
 </struts>

--- a/apps/struts20-example/pom.xml
+++ b/apps/struts20-example/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.blueskyminds.struts2.urlplugin</groupId>
   <artifactId>struts20-example</artifactId>
   <packaging>war</packaging>
-  <version>0.1-tizra.5</version>
+  <version>0.1-tizra.12</version>
   <name>Example Struts2.0.x WebApp with index actions</name>
   <url>http://www.blueskyminds.com.au</url>
 
@@ -17,16 +17,16 @@
 
   <dependencies>
 
-   <dependency>
+    <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.31</version>
+      <version>6.3.0.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.blueskyminds.struts2</groupId>
       <artifactId>struts20-url-plugin</artifactId>
-      <version>0.1-tizra.5</version>
+      <version>0.1-tizra.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/3.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.blueskyminds.struts2</groupId>
   <artifactId>struts2-url-plugin-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.1-tizra.10</version>
+  <version>0.1-tizra.12</version>
   <name>Struts2 URL Plugin Parent Module</name>
   <url>http://www.blueskyminds.com.au</url>
 
@@ -27,14 +27,14 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.12.1</version>
         <configuration>
          <release>17</release>
         </configuration>
       </plugin>
       <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.1.3</version>
+          <version>3.2.5</version>
           <configuration>
             <includes>
               <include>**/Test*.java</include>
@@ -44,26 +44,38 @@
     </plugins>
     <defaultGoal>install</defaultGoal>
   </build>
-  
-  <dependencies>  
+
+  <dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.10.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+  <dependencies>
 
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.0.4</version>
-    </dependency>    
+      <version>1.3.0</version>
+    </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
        <groupId>org.apache.struts</groupId>
        <artifactId>struts2-core</artifactId>
-       <version>2.5.31</version>
+       <version>6.3.0.2</version>
        <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/struts2-url-plugin-tests/pom.xml
+++ b/struts2-url-plugin-tests/pom.xml
@@ -5,14 +5,14 @@
   <groupId>com.blueskyminds.struts2.urlplugin</groupId>
   <artifactId>struts2-url-plugin-tests</artifactId>
   <packaging>jar</packaging>
-  <version>0.1-tizra.5</version>
+  <version>0.1-tizra.12</version>
   <name>Base test classes for Plugin Extensions</name>
   <url>http://www.blueskyminds.com.au</url>
   
   <parent>
     <groupId>com.blueskyminds.struts2</groupId>
     <artifactId>struts2-url-plugin-parent</artifactId>
-    <version>0.1-tizra.5</version>
+    <version>0.1-tizra.12</version>
   </parent>
 
   <dependencies>  
@@ -20,13 +20,13 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.31</version>
+      <version>6.3.0.2</version>
     </dependency>
     
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/struts2-url-plugin/pom.xml
+++ b/struts2-url-plugin/pom.xml
@@ -5,7 +5,7 @@
 <groupId>com.blueskyminds.struts2</groupId>
 <artifactId>struts2-url-plugin</artifactId>
 <packaging>jar</packaging>
-<version>0.1-tizra.11</version>
+<version>0.1-tizra.12</version>
 <name>Struts2 URL Plugin</name>
 <url>http://www.blueskyminds.com.au</url>
 
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.12.1</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<source>${maven.compiler.source}</source>
@@ -31,7 +31,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.2</version>
+				<version>3.3.1</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
@@ -56,7 +56,7 @@
 											maven-resources-plugin
 										</artifactId>
 										<versionRange>
-											[2.2,)
+											[3.3.1,)
 										</versionRange>
 										<goals>
 											<goal>testResources</goal>
@@ -74,31 +74,43 @@
 			</plugins>
 		</pluginManagement>
 	</build>
-	<dependencies>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.10.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
 	<dependency>
 	  <groupId>org.apache.struts</groupId>
 	  <artifactId>struts2-core</artifactId>
-	  <version>2.5.31</version>
+	  <version>6.3.0.2</version>
 	</dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
 
 	<dependency>
-	  <groupId>commons-digester</groupId>
-	  <artifactId>commons-digester</artifactId>
-	  <version>1.8</version>
+	  <groupId>org.apache.commons</groupId>
+	  <artifactId>commons-digester3</artifactId>
+	  <version>3.2</version>
 	</dependency>
 
 	<dependency>
 	  <groupId>javax.servlet</groupId>
-	  <artifactId>servlet-api</artifactId>
-	  <version>2.4</version>
+	  <artifactId>javax.servlet-api</artifactId>
+	  <version>3.1.0</version>
 	  <scope>provided</scope>
 	</dependency>
 

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/URLPatternActionMapper.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/URLPatternActionMapper.java
@@ -207,7 +207,8 @@ public class URLPatternActionMapper implements ActionMapper {
                                     transferParams(actionMapping, matchContext.evaluateProperties());
 
                                     if (LOG.isDebugEnabled()) {
-                                        Map map = actionMapping.getParams();
+                                        Map<String, Object> map = actionMapping
+                                                .getParams();
                                         LOG.debug("actionMapping.params = {");
                                         for (Object key : map.keySet()) {
                                             LOG.debug("   "+key+":"+map.get(key));

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/configuration/digester/XMLActionMapConfiguration.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/configuration/digester/XMLActionMapConfiguration.java
@@ -13,7 +13,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.net.URL;
 
-import org.apache.commons.digester.Digester;
+import org.apache.commons.digester3.Digester;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.Log;
 import org.xml.sax.SAXException;

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/expression/ExpressionProcessor.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/expression/ExpressionProcessor.java
@@ -125,6 +125,8 @@ public class ExpressionProcessor {
 					// restore the trailing $
 					result.append("$");
 				break;
+			case IN_TEXT:
+				break;
 			}
 
 			if (ExpressionProcessor.LOG.isDebugEnabled()) {

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/MatchContext.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/MatchContext.java
@@ -1,8 +1,5 @@
 package com.blueskyminds.struts2.urlplugin.matcher;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
@@ -21,8 +18,6 @@ import com.blueskyminds.struts2.urlplugin.expression.ExpressionProcessor;
  *       $1 is a reference to group #1  
  */
 public class MatchContext {
-
-    private static final Log LOG = LogFactory.getLog(MatchContext.class);
 
     private ExpressionProcessor expressionProcessor;
 

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/action/DefaultActionMatcher.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/action/DefaultActionMatcher.java
@@ -6,8 +6,6 @@ import org.apache.commons.logging.LogFactory;
 import com.blueskyminds.struts2.urlplugin.configuration.ActionSelector;
 import com.blueskyminds.struts2.urlplugin.matcher.action.namespace.NamespaceMatcher;
 import com.blueskyminds.struts2.urlplugin.matcher.action.name.ActionNameMatcher;
-import com.blueskyminds.struts2.urlplugin.matcher.action.MatcherProvider;
-import com.blueskyminds.struts2.urlplugin.matcher.action.ActionMatcher;
 import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
 import com.opensymphony.xwork2.config.Configuration;
 import com.opensymphony.xwork2.config.entities.PackageConfig;

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/uri/keyword/KeywordPatternMatcher.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/uri/keyword/KeywordPatternMatcher.java
@@ -50,13 +50,11 @@ public class KeywordPatternMatcher implements PatternMatcher {
         }
     }
 
-    private String keywordPattern;
     private Pattern regExPattern;
     private Map<String, Integer> keywordGroupMap;
 
 
     public KeywordPatternMatcher(String keywordPattern) {
-        this.keywordPattern = keywordPattern;
         keywordGroupMap = new HashMap<String, Integer>();
         
         if (keywordPattern != null) {

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/uri/keyword/KeywordURIMatcher.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/uri/keyword/KeywordURIMatcher.java
@@ -1,10 +1,6 @@
 package com.blueskyminds.struts2.urlplugin.matcher.uri.keyword;
 
 import com.blueskyminds.struts2.urlplugin.matcher.uri.DefaultURIMatcher;
-import com.blueskyminds.struts2.urlplugin.matcher.uri.URIMatcher;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * A specialisation of the DefaultURIMatcher that uses keywords for the commonly
@@ -14,9 +10,7 @@ import org.apache.commons.logging.LogFactory;
  * <p/>
  * History:
  */
-public class KeywordURIMatcher extends DefaultURIMatcher implements URIMatcher {
-
-    private static final Log LOG = LogFactory.getLog(KeywordURIMatcher.class);
+public class KeywordURIMatcher extends DefaultURIMatcher {
 
     public static final String DEFAULT_NAME = "keyword";
 

--- a/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/uri/regex/RegExURIMatcher.java
+++ b/struts2-url-plugin/src/main/java/com/blueskyminds/struts2/urlplugin/matcher/uri/regex/RegExURIMatcher.java
@@ -1,8 +1,6 @@
 package com.blueskyminds.struts2.urlplugin.matcher.uri.regex;
 
-import com.blueskyminds.struts2.urlplugin.matcher.uri.regex.RegExPatternMatcherFactory;
 import com.blueskyminds.struts2.urlplugin.matcher.uri.DefaultURIMatcher;
-import com.blueskyminds.struts2.urlplugin.matcher.uri.URIMatcher;
 
 /**
  * Sets up a URIMatcher that treats the method and path as a regular expression
@@ -13,7 +11,7 @@ import com.blueskyminds.struts2.urlplugin.matcher.uri.URIMatcher;
  * <p/>
  * History:
  */
-public class RegExURIMatcher extends DefaultURIMatcher implements URIMatcher {
+public class RegExURIMatcher extends DefaultURIMatcher {
 
     public static final String DEFAULT_NAME = "regex";
 

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/TestKeywordURLPatternMatcher.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/TestKeywordURLPatternMatcher.java
@@ -1,14 +1,13 @@
 package com.blueskyminds.struts2.urlplugin;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
- * Date Started: 22/02/2008
- * <p/>
- * History:
+ * The class this tests hasn't existed in the repo since the import to git.
  */
-public class TestKeywordURLPatternMatcher extends TestCase {
+public class TestKeywordURLPatternMatcher {
 
+    @Test
     public void testKeywordURLPatternMatcher() throws Exception {
 //        KeywordURLPatternMatcher matcher = new KeywordURLPatternMatcher("${namespace}/${action}${ext}");
 //        List<String> matches = matcher.matches("/exampleNamespace/example.action");

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/TestPatternActionMapper.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/TestPatternActionMapper.java
@@ -19,7 +19,11 @@ import com.opensymphony.xwork2.config.Configuration;
 
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the URLPatternActionMapper
@@ -28,7 +32,7 @@ import junit.framework.TestCase;
  * <p/>
  * History:
  */
-public class TestPatternActionMapper extends TestCase {
+public class TestPatternActionMapper {
 
     private Configuration configuration;
 
@@ -38,8 +42,7 @@ public class TestPatternActionMapper extends TestCase {
     private ActionMatcher actionMatcher;
     private ActionMapConfiguration actionMapConfiguration;
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    public TestPatternActionMapper() {
 
         //setup the MatcherProvider.  The matchers control how to match an ActionConfig
         actionMatcherProvider = new MockMatcherProvider<>();
@@ -64,6 +67,7 @@ public class TestPatternActionMapper extends TestCase {
     /**
      * match an action named 'example' in the /example namespace
      */
+    @Test
     public void testPackages() {
         URLPatternActionMapper actionMapper = new URLPatternActionMapper(actionMapConfiguration, actionMatcher, uriMatcherProvider);
         ActionMapping mapping = actionMapper.getMapping(new ComponentURI("get", "/example/example.action", null), configuration);

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/TestPatternActionMapper3.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/TestPatternActionMapper3.java
@@ -1,6 +1,10 @@
 package com.blueskyminds.struts2.urlplugin;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 import com.blueskyminds.struts2.urlplugin.configuration.ActionMapConfiguration;
 import com.blueskyminds.struts2.urlplugin.configuration.MockConfigurationFactory;
 import com.blueskyminds.struts2.urlplugin.configuration.digester.XMLActionMapConfiguration;
@@ -26,7 +30,7 @@ import org.apache.struts2.dispatcher.mapper.ActionMapping;
  * <p/>
  * History:
  */
-public class TestPatternActionMapper3 extends TestCase {
+public class TestPatternActionMapper3 {
 
     private ActionMapConfiguration actionMapConfiguration;
     private Configuration configuration;
@@ -36,9 +40,7 @@ public class TestPatternActionMapper3 extends TestCase {
     private MockMatcherProvider<URIMatcher> uriMatcherProvider;
     private ActionMatcher actionMatcher;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    public TestPatternActionMapper3() {
         actionMapConfiguration = new XMLActionMapConfiguration();
         ((XMLActionMapConfiguration) actionMapConfiguration).setConfiguration("struts-test3-urls.xml");
 
@@ -59,6 +61,7 @@ public class TestPatternActionMapper3 extends TestCase {
         configuration = MockConfigurationFactory.createConfiguration();
     }
 
+    @Test
     public void testMapper() {
         URLPatternActionMapper actionMapper = new URLPatternActionMapper(actionMapConfiguration, actionMatcher, uriMatcherProvider);
         ActionMapping mapping = actionMapper.getMapping(new ComponentURI("GET", "/example/example.action", null), configuration);

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/configuration/MockConfigurationFactory.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/configuration/MockConfigurationFactory.java
@@ -4,8 +4,6 @@ import com.opensymphony.xwork2.config.impl.MockConfiguration;
 import com.opensymphony.xwork2.config.entities.PackageConfig;
 import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.config.Configuration;
-import com.blueskyminds.struts2.urlplugin.configuration.Example1Action;
-import com.blueskyminds.struts2.urlplugin.configuration.Example2Action;
 
 /**
  * Used to setup Struts2 configuration for testing

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/configuration/SampleOriginalActionMapConfiguration.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/configuration/SampleOriginalActionMapConfiguration.java
@@ -1,9 +1,5 @@
 package com.blueskyminds.struts2.urlplugin.configuration;
 
-import com.blueskyminds.struts2.urlplugin.configuration.ActionMapConfiguration;
-import com.blueskyminds.struts2.urlplugin.configuration.ActionMapDefinition;
-import com.blueskyminds.struts2.urlplugin.configuration.URIPattern;
-import com.blueskyminds.struts2.urlplugin.configuration.ActionSelector;
 import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
 
 import java.util.List;

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/configuration/TestXMLConfiguration.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/configuration/TestXMLConfiguration.java
@@ -1,8 +1,9 @@
 package com.blueskyminds.struts2.urlplugin.configuration;
 
-import junit.framework.TestCase;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 import com.blueskyminds.struts2.urlplugin.configuration.digester.XMLActionMapConfiguration;
 import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
 
@@ -13,15 +14,12 @@ import java.util.List;
  * <p/>
  * History:
  */
-public class TestXMLConfiguration extends TestCase {
+public class TestXMLConfiguration {
 
-    private static final Log LOG = LogFactory.getLog(TestXMLConfiguration.class);
-
+    @Test
     public void testReadConfig() throws Exception {
         XMLActionMapConfiguration configuration = new XMLActionMapConfiguration();
         configuration.setConfiguration("struts-test1-urls.xml");
-
-        MatchContext matchContext = configuration.prepareMatchContext();
 
         List<ActionMapDefinition> actionMappings = configuration.getActionMappings();
         assertEquals(1, actionMappings.size());
@@ -46,8 +44,9 @@ public class TestXMLConfiguration extends TestCase {
         assertEquals(2, pattern2.getParams().size());
         assertEquals("/", pattern2.getParams().get("path"));
         assertEquals("$1", pattern2.getParams().get("name"));
-   }
+    }
 
+    @Test
     public void testReadConfig2() throws Exception {
         XMLActionMapConfiguration configuration = new XMLActionMapConfiguration();
         configuration.setConfiguration("struts-test2-urls.xml");
@@ -81,8 +80,9 @@ public class TestXMLConfiguration extends TestCase {
         ActionSelector firstSelector = selectors.get(0);
         ActionSelector secondSelector = selectors.get(1);
         assertEquals(1, firstSelector.getParams().size());
-   }
+    }
 
+    @Test
     public void testReadConfig3() throws Exception {
         XMLActionMapConfiguration configuration = new XMLActionMapConfiguration();
         configuration.setConfiguration("struts-test3-urls.xml");
@@ -121,5 +121,5 @@ public class TestXMLConfiguration extends TestCase {
         ActionSelector firstSelector = selectors.get(0);
         ActionSelector secondSelector = selectors.get(1);
         assertEquals(1, firstSelector.getParams().size());
-   }
+    }
 }

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/TestDefaultActionMatcher.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/TestDefaultActionMatcher.java
@@ -1,6 +1,8 @@
 package com.blueskyminds.struts2.urlplugin.matcher;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
 import com.blueskyminds.struts2.urlplugin.matcher.action.namespace.PlainTextNamespaceMatcher;
 import com.blueskyminds.struts2.urlplugin.matcher.action.namespace.NamespaceMatcher;
 import com.blueskyminds.struts2.urlplugin.matcher.action.name.PlainTextActionNameMatcher;
@@ -19,28 +21,38 @@ import org.apache.struts2.dispatcher.mapper.ActionMapping;
  * <p/>
  * History:
  */
-public class TestDefaultActionMatcher extends TestCase {
+public class TestDefaultActionMatcher {
 
     private MockMatcherProvider<ActionNameMatcher> actionMatcherProvider;
     private MockMatcherProvider<NamespaceMatcher> namespaceMatcherProvider;
     private ActionMatcher actionMatcher;
     private Configuration configuration;
 
-    protected void setUp() throws Exception {
-        super.setUp();
 
-        //setup the MatcherProvider.  The matchers control how to match an ActionConfig
-        actionMatcherProvider = new MockMatcherProvider<ActionNameMatcher>();
-        actionMatcherProvider.addMatcher(PlainTextActionNameMatcher.DEFAULT_NAME, new PlainTextActionNameMatcher());
+    public TestDefaultActionMatcher() {
+        try {
+            // setup the MatcherProvider. The matchers control how to match an
+            // ActionConfig
+            actionMatcherProvider = new MockMatcherProvider<ActionNameMatcher>();
+            actionMatcherProvider.addMatcher(
+                    PlainTextActionNameMatcher.DEFAULT_NAME,
+                    new PlainTextActionNameMatcher());
 
-        namespaceMatcherProvider = new MockMatcherProvider<NamespaceMatcher>();
-        namespaceMatcherProvider.addMatcher(PlainTextNamespaceMatcher.DEFAULT_NAME, new PlainTextNamespaceMatcher());
+            namespaceMatcherProvider = new MockMatcherProvider<NamespaceMatcher>();
+            namespaceMatcherProvider.addMatcher(
+                    PlainTextNamespaceMatcher.DEFAULT_NAME,
+                    new PlainTextNamespaceMatcher());
 
-        configuration = MockConfigurationFactory.createConfiguration();
+            configuration = MockConfigurationFactory.createConfiguration();
 
-        actionMatcher = new DefaultActionMatcher(namespaceMatcherProvider, actionMatcherProvider);
+            actionMatcher = new DefaultActionMatcher(namespaceMatcherProvider,
+                    actionMatcherProvider);
+        } catch (Exception ex) {
+            throw new RuntimeException("Setup error", ex);
+        }
     }
 
+    @Test
     public void testActionMatcher() {
         MatchContext matchContext = new MatchContext();
         matchContext.put("path", "/example");

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/TestMatchContext.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/TestMatchContext.java
@@ -1,18 +1,17 @@
 package com.blueskyminds.struts2.urlplugin.matcher;
 
-import junit.framework.TestCase;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Date Started: 29/01/2008
  * <p/>
  * History:
  */
-public class TestMatchContext extends TestCase {
+public class TestMatchContext {
 
-    private static final Log LOG = LogFactory.getLog(TestMatchContext.class);
-
+    @Test
     public void testGroupMatch() {
 
         MatchContext matchContext = new MatchContext();
@@ -33,6 +32,7 @@ public class TestMatchContext extends TestCase {
     }
 
 
+    @Test
     public void testParamMatch() {
 
         MatchContext matchContext = new MatchContext();

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/action/namespace/TestNamedVariableNamespaceMatcher.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/action/namespace/TestNamedVariableNamespaceMatcher.java
@@ -1,6 +1,10 @@
 package com.blueskyminds.struts2.urlplugin.matcher.action.namespace;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
 
 /**
@@ -8,8 +12,9 @@ import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
  * <p/>
  * History:
  */
-public class TestNamedVariableNamespaceMatcher extends TestCase {
+public class TestNamedVariableNamespaceMatcher {
 
+    @Test
     public void testNamespaceVariables() {
         NamedVariableNamespaceMatcher matcher = new NamedVariableNamespaceMatcher();
         MatchContext matchContext = new MatchContext();
@@ -30,6 +35,7 @@ public class TestNamedVariableNamespaceMatcher extends TestCase {
         assertEquals("test1", matchContext.get("var3"));
     }
 
+    @Test
     public void testNamespaceVariablesWithSlashes() {
         NamedVariableNamespaceMatcher matcher = new NamedVariableNamespaceMatcher();
         MatchContext matchContext = new MatchContext();

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/configuration/TestRegExPatternMatcher.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/configuration/TestRegExPatternMatcher.java
@@ -11,7 +11,11 @@ import org.apache.commons.logging.LogFactory;
 import java.util.Collection;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the default RegEx PatternMatcher
@@ -20,20 +24,15 @@ import junit.framework.TestCase;
  * <p/>
  * History:
  */
-public class TestRegExPatternMatcher extends TestCase {
+public class TestRegExPatternMatcher {
 
     private static final Log LOG = LogFactory.getLog(TestRegExPatternMatcher.class);
 
-    private PatternMatcherFactory factory;
-    private MatchContext matchContext;
-
-    protected void setUp() throws Exception {
-        super.setUp();
-        factory = new RegExPatternMatcherFactory();
-        matchContext = new MatchContext();
-    }
+    private PatternMatcherFactory factory = new RegExPatternMatcherFactory();
+    private MatchContext matchContext = new MatchContext();
 
     /** Match everything - no groups */
+    @Test
     public void testMatchNotNull() {
         PatternMatcher matcher = factory.get(".*");
         assertNotNull(matcher.matches("", matchContext));
@@ -43,6 +42,7 @@ public class TestRegExPatternMatcher extends TestCase {
     }
 
     /** Null pattern always succeeds */
+    @Test
     public void testMatchAll() {
         PatternMatcher matcher = factory.get(null);
         assertTrue(matcher.matches("", matchContext));
@@ -52,6 +52,7 @@ public class TestRegExPatternMatcher extends TestCase {
     }
 
     /** A commonly used path */
+    @Test
     public void testMatchPath() {
         PatternMatcher matcher = factory.get("/example/.+");
         assertFalse(matcher.matches("", matchContext));  // no match
@@ -64,6 +65,7 @@ public class TestRegExPatternMatcher extends TestCase {
     }
 
     /** Another commonly used path */
+    @Test
     public void testMatchPath2() {
         PatternMatcher matcher = factory.get("/example/.*");
         assertFalse(matcher.matches("", matchContext));  // no match
@@ -167,6 +169,7 @@ public class TestRegExPatternMatcher extends TestCase {
     }
 
     /** Matches any path containing .action */
+    @Test
     public void testGroup1() {
         PatternMatcher matcher = factory.get("^(.*)/(.*)\\.action$");
         assertFalse(matcher.matches("", matchContext));  // no match

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/uri/TestDefaultURIMatcher.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/uri/TestDefaultURIMatcher.java
@@ -1,9 +1,11 @@
 package com.blueskyminds.struts2.urlplugin.matcher.uri;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 import com.blueskyminds.struts2.urlplugin.configuration.URIPattern;
 import com.blueskyminds.struts2.urlplugin.utils.ComponentURI;
-import com.blueskyminds.struts2.urlplugin.matcher.uri.DefaultURIMatcher;
 import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
 
 /**
@@ -13,18 +15,12 @@ import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
  * <p/>
  * History:
  */
-public class TestDefaultURIMatcher extends TestCase {
+public class TestDefaultURIMatcher {
 
-    private DefaultURIMatcher uriMatcher;
-    private MatchContext matchContext;
+    private DefaultURIMatcher uriMatcher = new DefaultURIMatcher();
+    private MatchContext matchContext = new MatchContext();
 
-    protected void setUp() throws Exception {
-        super.setUp();
-
-        uriMatcher = new DefaultURIMatcher();
-        matchContext = new MatchContext();
-    }
-
+    @Test
     public void testMatch() {
         URIPattern uriPattern = new URIPattern("1", "regex", "GET", ".*");
 

--- a/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/uri/TestKeywordURIMatcher.java
+++ b/struts2-url-plugin/src/test/java/com/blueskyminds/struts2/urlplugin/matcher/uri/TestKeywordURIMatcher.java
@@ -1,6 +1,9 @@
 package com.blueskyminds.struts2.urlplugin.matcher.uri;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 import com.blueskyminds.struts2.urlplugin.configuration.URIPattern;
 import com.blueskyminds.struts2.urlplugin.utils.ComponentURI;
 import com.blueskyminds.struts2.urlplugin.matcher.uri.keyword.KeywordURIMatcher;
@@ -13,18 +16,12 @@ import com.blueskyminds.struts2.urlplugin.matcher.MatchContext;
  * <p/>
  * History:
  */
-public class TestKeywordURIMatcher extends TestCase {
+public class TestKeywordURIMatcher {
 
-    private KeywordURIMatcher uriMatcher;
-    private MatchContext matchContext;
+    private KeywordURIMatcher uriMatcher = new KeywordURIMatcher();
+    private MatchContext matchContext = new MatchContext();
 
-    protected void setUp() throws Exception {
-        super.setUp();
-
-        uriMatcher = new KeywordURIMatcher();
-        matchContext = new MatchContext();
-    }
-
+    @Test
     public void testMatch() {
         URIPattern uriPattern = new URIPattern("1", "keyword", "GET", "namespace/action[ext]");
         assertTrue(uriMatcher.matchesPath(new ComponentURI("get", "/exampleNamespace/example.action", null), uriPattern, matchContext));

--- a/struts20-url-plugin/pom.xml
+++ b/struts20-url-plugin/pom.xml
@@ -5,14 +5,14 @@
   <groupId>com.blueskyminds.struts2</groupId>
   <artifactId>struts20-url-plugin</artifactId>
   <packaging>jar</packaging>
-  <version>0.1-tizra.11</version>
+  <version>0.1-tizra.12</version>
   <name>Struts2.0 URL Plugin</name>
   <url>http://www.blueskyminds.com.au</url>
 
   <parent>
     <groupId>com.blueskyminds.struts2</groupId>
     <artifactId>struts2-url-plugin-parent</artifactId>
-    <version>0.1-tizra.10</version>
+    <version>0.1-tizra.12</version>
   </parent>
 
   <!--
@@ -38,19 +38,19 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.31</version>
+      <version>6.3.0.2</version>
     </dependency>
 
     <dependency>
-       <groupId>commons-digester</groupId>
-       <artifactId>commons-digester</artifactId>
-       <version>1.8</version>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-digester3</artifactId>
+       <version>3.2</version>
      </dependency>
     
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/struts20-url-plugin/src/test/java/com/blueskyminds/struts20/urlplugin/configuration/MockConfigurationFactory.java
+++ b/struts20-url-plugin/src/test/java/com/blueskyminds/struts20/urlplugin/configuration/MockConfigurationFactory.java
@@ -35,22 +35,23 @@ public class MockConfigurationFactory {
     public static Configuration createConfiguration() {
         // setup a Struts2 configuration
         Configuration configuration = new MockConfiguration();
-        PackageConfig defaultPackage = new PackageConfig(DEFAULT_PACKAGE_NAME, DEFAULT_PACKAGE_NAMESPACE, false);
-
         // Example1Action is used in the default package as well as package1.  The only difference is namespace
-        ActionConfig default1Action = new ActionConfig();
-        default1Action.setClassName(Example1Action.class.getName());
-        defaultPackage.addActionConfig(ACTION1_NAME, default1Action);
+        ActionConfig default1Action = new ActionConfig.Builder("com.blueskyminds.struts20.urlplugin.configuration",
+            "example1", Example1Action.class.getName()).build();
+        PackageConfig defaultPackage = new PackageConfig.Builder(DEFAULT_PACKAGE_NAME)
+                .namespace(DEFAULT_PACKAGE_NAMESPACE).strictMethodInvocation(false)
+                .addActionConfig(ACTION1_NAME, default1Action).build();
 
-        PackageConfig example1Package = new PackageConfig(PACKAGE1_NAME, PACKAGE1_NAMESPACE, false);
-        ActionConfig example1Action = new ActionConfig();
-        example1Action.setClassName(com.blueskyminds.struts20.urlplugin.configuration.Example1Action.class.getName());
-        example1Package.addActionConfig(ACTION1_NAME, example1Action);
 
+        ActionConfig example1Action = new ActionConfig.Builder("com.blueskyminds.struts20.urlplugin.configuration",
+            "example1", Example1Action.class.getName()).build();
         // Example2Action is used only in package1
-        ActionConfig example2Action = new ActionConfig();
-        example2Action.setClassName(Example2Action.class.getName());
-        example1Package.addActionConfig(ACTION2_NAME, example2Action);
+        ActionConfig example2Action = new ActionConfig.Builder("com.blueskyminds.struts20.urlplugin.configuration",
+            "example2", Example2Action.class.getName()).build();
+        PackageConfig example1Package = new PackageConfig.Builder(PACKAGE1_NAME)
+                .namespace(PACKAGE1_NAMESPACE).strictMethodInvocation(false)
+                .addActionConfig(ACTION1_NAME, example1Action)
+                .addActionConfig(ACTION2_NAME, example2Action).build();
 
         configuration.addPackageConfig(DEFAULT_PACKAGE_NAME, defaultPackage);
         configuration.addPackageConfig(PACKAGE1_NAME, example1Package);

--- a/struts20-url-plugin/src/test/java/com/blueskyminds/struts20/urlplugin/configuration/MockMatcherProvider.java
+++ b/struts20-url-plugin/src/test/java/com/blueskyminds/struts20/urlplugin/configuration/MockMatcherProvider.java
@@ -1,5 +1,6 @@
 package com.blueskyminds.struts20.urlplugin.configuration;
 
+import com.blueskyminds.struts2.urlplugin.matcher.action.MatcherProvider;
 
 import java.util.Map;
 import java.util.HashMap;

--- a/struts20-url-plugin/src/test/java/com/blueskyminds/struts20/urlplugin/configuration/TestPatternActionMapper.java
+++ b/struts20-url-plugin/src/test/java/com/blueskyminds/struts20/urlplugin/configuration/TestPatternActionMapper.java
@@ -1,6 +1,10 @@
 package com.blueskyminds.struts20.urlplugin.configuration;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 import com.opensymphony.xwork2.config.Configuration;
 import com.blueskyminds.struts2.urlplugin.configuration.ActionMapConfiguration;
 import com.blueskyminds.struts2.urlplugin.matcher.action.name.PlainTextActionNameMatcher;
@@ -24,7 +28,7 @@ import org.apache.struts2.dispatcher.mapper.ActionMapping;
  * <p/>
  * History:
  */
-public class TestPatternActionMapper extends TestCase {
+public class TestPatternActionMapper {
 
     private Configuration configuration;
 
@@ -34,9 +38,7 @@ public class TestPatternActionMapper extends TestCase {
     private ActionMatcher actionMatcher;
     private ActionMapConfiguration actionMapConfiguration;
 
-    protected void setUp() throws Exception {
-        super.setUp();
-
+    public TestPatternActionMapper() {
         //setup the MatcherProvider.  The matchers control how to match an ActionConfig
         actionMatcherProvider = new MockMatcherProvider<ActionNameMatcher>();
         actionMatcherProvider.addMatcher(PlainTextActionNameMatcher.DEFAULT_NAME, new PlainTextActionNameMatcher());
@@ -60,6 +62,7 @@ public class TestPatternActionMapper extends TestCase {
     /**
      * match an action named 'example' in the /example namespace
      */
+    @Test
     public void testPackages() {
         URLPatternActionMapper actionMapper = new URLPatternActionMapper(actionMapConfiguration, actionMatcher, uriMatcherProvider);
         ActionMapping mapping = actionMapper.getMapping(new ComponentURI("get", "/example/example.action", null), configuration);


### PR DESCRIPTION
All dependencies upgraded to latest stable versions.

Many of the files I modified had DOS carriage returns (?) so I converted them to newline-only with `dos2unix`.  I’m sorry that makes the diff harder to read.

As far as I can tell, nothing significant changed.  Most of my code updates were in the tests.